### PR TITLE
lazy action types example

### DIFF
--- a/src/demo/actions/lazy.ts
+++ b/src/demo/actions/lazy.ts
@@ -1,0 +1,36 @@
+/**
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+import * as r from 'redux';
+export const TOGGLE = 'TOGGLE';
+export const FORCE_TOGGLE = 'FORCE_TOGGLE';
+
+export interface LazyActionToggle extends r.Action<'TOGGLE'> { };
+export interface LazyActionForceToggle extends r.Action<'FORCE_TOGGLE'> {
+  value: boolean,
+};
+export type LazyAction = LazyActionToggle | LazyActionForceToggle;
+
+export const toggle = () => {
+  const action: LazyActionToggle = {
+    type: TOGGLE,
+  };
+
+  return action
+};
+
+export const forceToggle = (value: boolean) => {
+  const action: LazyActionForceToggle = {
+    type: FORCE_TOGGLE,
+    value
+  };
+
+  return action
+};

--- a/src/demo/components/redux-example.ts
+++ b/src/demo/components/redux-example.ts
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import './counter-element.js';
 import { connect } from '../../connect-mixin.js';
-import { store, AppState, AppStateLazy } from '../store.js';
+import { store, RootLazyState, RootState } from '../store.js';
 import { increment, decrement } from '../actions/counter.js';
 import * as r from 'redux';
 
@@ -32,17 +32,27 @@ template.innerHTML = `
     <li><code>clicks = <span id="clicksSpan"></span></code></li>
     <li><code>value = <span id="valueSpan"></span></code></li>
     <li><code>didLoad = <span id="didLoadSpan"></span></code></li>
+    <li><code>toggleValue = <span id="lazyToggleSpan"></span></code></li>
   </ul>
   <counter-element></counter-element>
-  <button>Load lazy reducer</button>
+  <button id="lazyLoadButton">Load lazy reducer</button>
+  <button id="lazyActionButtonOn">Lazy Action Toggle On</button>
+  <button id="lazyActionButtonOff">Lazy Action Toggle Off</button>
+  <button id="lazyActionButton">Lazy Action Toggle</button>
 </div>
 `
 
 class ReduxExample extends connect(store)(HTMLElement) {
-  _counter: CounterElement
-  _clicksSpan: HTMLElement
-  _valueSpan: HTMLElement
-  _didLoadSpan: HTMLElement
+  _counter: CounterElement;
+  _clicksSpan: HTMLElement;
+  _valueSpan: HTMLElement;
+  _didLoadSpan: HTMLElement;
+  _lazyToggleSpan: HTMLElement;
+  _lazyLoadButton: HTMLButtonElement;
+  _lazyActionButtonOn: HTMLButtonElement;
+  _lazyActionButtonOff: HTMLButtonElement;
+  _lazyActionButton: HTMLButtonElement;
+
   constructor() {
     super();
 
@@ -55,30 +65,55 @@ class ReduxExample extends connect(store)(HTMLElement) {
     this._clicksSpan = shadowRoot.getElementById('clicksSpan')!;
     this._valueSpan = shadowRoot.getElementById('valueSpan')!;
     this._didLoadSpan = shadowRoot.getElementById('didLoadSpan')!;
+    this._lazyToggleSpan = shadowRoot.getElementById('lazyToggleSpan')!;
+    this._lazyLoadButton = shadowRoot.getElementById('lazyLoadButton')! as HTMLButtonElement;
+    this._lazyActionButtonOn = shadowRoot.getElementById('lazyActionButtonOn')! as HTMLButtonElement;
+    this._lazyActionButtonOff = shadowRoot.getElementById('lazyActionButtonOff')! as HTMLButtonElement;
+    this._lazyActionButton = shadowRoot.getElementById('lazyActionButton')! as HTMLButtonElement;
 
     // Every time the display of the counter updates, we should save
     // these values in the store.
     this.addEventListener('counter-incremented', () => store.dispatch(increment()));
     this.addEventListener('counter-decremented', () => store.dispatch(decrement()));
 
-    shadowRoot.querySelector('button')!.addEventListener('click',
+    this._lazyLoadButton.addEventListener('click',
         () => this._loadReducer());
+
+    this._lazyActionButtonOn.addEventListener('click',
+        () => this._toggleLazy(true));
+    this._lazyActionButtonOff.addEventListener('click',
+        () => this._toggleLazy(false));
+    this._lazyActionButton.addEventListener('click',
+        () => this._toggleLazy());
   }
 
-  _stateChanged(state: AppState) {
+  _stateChanged(state: RootState) {
     const numClicks = this._counter.clicks = state.counter.clicks;
     const value = this._counter.value = state.counter.value;
     // Update the UI.
     this._clicksSpan.textContent = numClicks.toString();
     this._valueSpan.textContent = value.toString();
     this._didLoadSpan.textContent = state.lazy ? state.lazy.didLoad.toString() : 'undefined';
+    this._lazyToggleSpan.textContent = state.lazy ? state.lazy.toggleValue.toString() : 'undefined';
   }
 
   _loadReducer() {
     import('../reducers/lazy.js').then((module) => {
       const reducer = module.default;
-      const reducerMap: r.ReducersMapObject<AppStateLazy> = {'lazy': reducer};
+      const reducerMap: r.ReducersMapObject<RootLazyState> = {'lazy': reducer};
       store.addReducers(reducerMap);
+    });
+  }
+
+  _toggleLazy(value?: boolean) {
+    import('../actions/lazy.js').then((module) => {
+      if (value === undefined) {
+        store.dispatch(module.toggle());
+
+        return;
+      }
+
+      store.dispatch(module.forceToggle(value));
     });
   }
 

--- a/src/demo/reducers/lazy.ts
+++ b/src/demo/reducers/lazy.ts
@@ -8,13 +8,29 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 import * as r from 'redux';
+import { LazyAction, TOGGLE, FORCE_TOGGLE } from '../actions/lazy';
 
 export interface LazyState {
-  didLoad: boolean
+  didLoad: boolean,
+  toggleValue: boolean
 }
 // This reducer doesn't do anything other than boot up.
-const lazy:r.Reducer<LazyState> = (state = {didLoad:true}) => {
-  return state;
+const lazy:r.Reducer<LazyState, LazyAction> = (state = {didLoad:true, toggleValue:false}, action) => {
+  switch (action.type) {
+    case TOGGLE:
+      return {
+        ...state,
+        toggleValue: !state.toggleValue
+      }
+    case FORCE_TOGGLE:
+      return {
+        ...state,
+        toggleValue: action.value
+      }
+    default:
+      return state;
+  }
+
 }
 
 export default lazy;

--- a/src/demo/store.ts
+++ b/src/demo/store.ts
@@ -17,21 +17,26 @@ declare global {
 
 import * as r from 'redux';
 import * as enhancers from '../lazy-reducer-enhancer.js'
-import { CounterAction } from './actions/counter.js';
+import * as counterActions from './actions/counter.js';
+import * as lazyActions from './actions/lazy';
 import { LazyState } from './reducers/lazy.js';
 
 // static states
-export interface AppStateCounter {
+export interface RootStateCounter {
   counter: CounterState
 }
 
 // lazy states
-export interface AppStateLazy {
+export interface RootLazyState {
   lazy: LazyState
 }
 
-// overall state extends static states and partials lazy states
-export interface AppState extends AppStateCounter, Partial<AppStateLazy> {}
+// root action is an or of all actions lazy or not. If there is no reducer
+// it will simply not execute
+type RootAction = counterActions.CounterAction | lazyActions.LazyAction;
+
+// root state extends static states and partials of lazy states
+export type RootState = RootStateCounter & Partial<RootLazyState>;
 
 // Initially loaded reducers.
 import counter, { CounterState } from './reducers/counter.js';
@@ -43,9 +48,9 @@ const newCompose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || r.compose;
 // Initializes the Redux store with a lazyReducerEnhancer (so that you can
 // lazily add reducers after the store has been created).
 export const store = r.createStore(
-  ((state) => state) as r.Reducer<AppState, CounterAction>,
+  ((state) => state) as r.Reducer<RootState, RootAction>,
   newCompose(enhancers.lazyReducerEnhancer(r.combineReducers))
 );
 
-const reducer: r.ReducersMapObject<AppStateCounter, CounterAction> = { counter };
+const reducer: r.ReducersMapObject<RootStateCounter, counterActions.CounterAction> = { counter };
 store.addReducers(reducer);


### PR DESCRIPTION
added an action to lazy to show how to deal with lazy actions as well as non-lazy actions in typings. Also renamed some types to follow what I believe is canonical type naming in Redux. Adding only one action seems to have made the demo quire a bit more complex than I expected.

reviewers added: project owners and TS nerds