### PR TITLE
Add support for meta description

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -37,6 +37,7 @@ export const updateMetadata = ({title, description, url, image}) => {
   }
 
   if (description) {
+    _setMeta('name', 'description', description);
     _setMeta('property', 'og:description', description);
     _setMeta('property', 'twitter:description', description);
   }


### PR DESCRIPTION
Not sure if this is was done on purpose, but the description meta tag does not get updated when `description` is provided to the `updateMetadata` function. This PR fixes this behavior by updating the description meta tag too.

Fixes #31 