### PR TITLE
interface LazyStore extends Store

### DIFF
--- a/src/lazy-reducer-enhancer.ts
+++ b/src/lazy-reducer-enhancer.ts
@@ -28,9 +28,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     someReducer
   });
 */
-import { ReducersMapObject, StoreEnhancer } from 'redux'
+import { ReducersMapObject, StoreEnhancer, Store } from 'redux'
 
-export interface LazyStore {
+export interface LazyStore extends Store {
   addReducers: (newReducers: ReducersMapObject) => void
 }
 


### PR DESCRIPTION
with this change snippet below works
```ts
import { lazyReducerEnhancer, LazyStore } from 'pwa-helpers/lazy-reducer-enhancer.js'

const store = createStore(
  state => state,
  devCompose(lazyReducerEnhancer(combineReducers))
) as LazyStore
```

without it I get in my application error `Property 'getState' does not exist on type 'LazyStore'.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/pwa-helpers/44)
<!-- Reviewable:end -->
